### PR TITLE
Mateus-implementar-acesso-conceitual-a-api-de-cep

### DIFF
--- a/frontend/src/app/app.component.ts
+++ b/frontend/src/app/app.component.ts
@@ -2,6 +2,7 @@ import { Component } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { RouterOutlet } from '@angular/router';
 import { MenuComponent } from './components/menu/menu.component';
+import { CepService } from './services/cep/cep.service';
 
 @Component({
   selector: 'app-root',
@@ -12,4 +13,18 @@ import { MenuComponent } from './components/menu/menu.component';
 })
 export class AppComponent {
   title = 'Trabalho-Final';
+
+  constructor(cepService: CepService) {
+    cepService.ObterEndereco('01001-000').subscribe({
+      next: (endereco) => {
+        console.log(endereco);
+      },
+      error: (error) => {
+        console.error('Erro ao obter endereço:', error);
+      },
+      complete: () => {
+        console.log('Requisição concluída');
+      }
+    });
+  }
 }

--- a/frontend/src/app/app.config.ts
+++ b/frontend/src/app/app.config.ts
@@ -3,7 +3,8 @@ import { provideRouter } from '@angular/router';
 
 import { routes } from './app.routes';
 import { provideClientHydration } from '@angular/platform-browser';
+import { provideHttpClient } from '@angular/common/http';
 
 export const appConfig: ApplicationConfig = {
-  providers: [provideRouter(routes), provideClientHydration()]
+  providers: [provideRouter(routes), provideClientHydration(), provideHttpClient(),]
 };

--- a/frontend/src/app/models/endereco.ts
+++ b/frontend/src/app/models/endereco.ts
@@ -1,0 +1,7 @@
+export class Endereco {
+    cep: string = "";
+    logradouro: string = "";
+    bairro: string = "";
+    localidade: string = "";
+    uf: string = "";
+}

--- a/frontend/src/app/services/cep/cep.service.spec.ts
+++ b/frontend/src/app/services/cep/cep.service.spec.ts
@@ -1,0 +1,16 @@
+import { TestBed } from '@angular/core/testing';
+
+import { CepService } from './cep.service';
+
+describe('CepService', () => {
+  let service: CepService;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({});
+    service = TestBed.inject(CepService);
+  });
+
+  it('should be created', () => {
+    expect(service).toBeTruthy();
+  });
+});

--- a/frontend/src/app/services/cep/cep.service.ts
+++ b/frontend/src/app/services/cep/cep.service.ts
@@ -1,0 +1,17 @@
+import { Injectable } from '@angular/core';
+import { Endereco } from '../../models/endereco';
+import { HttpClient } from '@angular/common/http';
+import { Observable } from 'rxjs';
+
+@Injectable({
+  providedIn: 'root'
+})
+export class CepService {
+  private baseUrl = 'https://viacep.com.br/ws/';
+
+  constructor(private http: HttpClient) { }
+
+  ObterEndereco(cep: string): Observable<Endereco> {
+    return this.http.get<Endereco>(`${this.baseUrl}${cep}/json/`);
+  }
+}


### PR DESCRIPTION
Implementação inicial do serviço de obtenção de endereço através do cep
(pendentes demais decisões sobre organização de pastas e arquivos, e padrões de nomenclatura)